### PR TITLE
Change websocketUrl default to use internal addon name

### DIFF
--- a/matter_door_lock.py
+++ b/matter_door_lock.py
@@ -148,7 +148,7 @@ async def main(args: Sequence[str] | None = None) -> None:
         dest="websocketUrl",
         action="store",
         type=str,
-        default="ws://localhost:5580/ws",
+        default="ws://core-matter-server:5580/ws",
     )
     prog.add_argument(
         "--timeout",


### PR DESCRIPTION
Obviously this is going to be install dependent, so maybe it's just better to document this in the readme.